### PR TITLE
chore(#4): include package.json 1.0.3 bump and lockfile for published patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@renderx-plugins/host-sdk",
-  "version": "0.3.0",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@renderx-plugins/host-sdk",
-      "version": "0.3.0",
+      "version": "1.0.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renderx-plugins/host-sdk",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "type": "module",
   "description": "Host SDK for RenderX plugins - provides conductor, event routing, and component mapping APIs",
   "keywords": [


### PR DESCRIPTION
This PR tracks the already-published 1.0.3 patch and ensures repository state includes the version bump and lockfile changes.

- package.json: 1.0.3
- package-lock.json: updated

Context
- Issue #4 addressed in prior commits (explicit subpath exports, safe conductor barrel, no-op EventRouter.init, removal of raw JSON imports in manifests/startup). Those are already on main and published; this PR simply captures the version bump in a branch + PR for review/history.

CI
- type-check: OK
- tests: 56 passing
- build: OK

Once merged, main will match the published 1.0.3 artifacts and the history will link to issue #4 for the bump.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author