### PR TITLE
docs(ci): fix Integration Guide CSS example and testing guide

### DIFF
--- a/RenderX.HostSDK.Avalonia/INTEGRATION_GUIDE.md
+++ b/RenderX.HostSDK.Avalonia/INTEGRATION_GUIDE.md
@@ -73,6 +73,7 @@ Example: get inventory and register CSS classes.
 <augment_code_snippet mode="EXCERPT">
 ````csharp
 using RenderX.HostSDK.Avalonia.Interfaces;
+using RenderX.HostSDK.Avalonia.Models;
 
 public sealed class UiInit(
     IInventoryAPI inventory,
@@ -87,7 +88,11 @@ public sealed class UiInit(
         }
 
         // Register a CSS utility class
-        await css.RegisterClassAsync(".rx-hidden", "display:none;");
+        await css.CreateClassAsync(new CssClassDef
+        {
+            Name = "rx-hidden",
+            Rules = ".rx-hidden { display: none; }"
+        });
     }
 }
 ````

--- a/RenderX.HostSDK.Avalonia/TESTING.md
+++ b/RenderX.HostSDK.Avalonia/TESTING.md
@@ -9,7 +9,7 @@ This repo contains a comprehensive xUnit test suite for the Avalonia Host SDK. B
 dotnet build MusicalConductor.sln -c Release --nologo
 
 # Run only the Host SDK tests
-Dotnet test RenderX.HostSDK.Avalonia/Tests/RenderX.HostSDK.Avalonia.Tests.csproj -c Release --nologo
+dotnet test RenderX.HostSDK.Avalonia/Tests/RenderX.HostSDK.Avalonia.Tests.csproj -c Release --nologo
 ````
 </augment_code_snippet>
 


### PR DESCRIPTION
This PR fixes two documentation issues:

- Integration Guide: Replace incorrect ICssRegistryAPI example (`RegisterClassAsync`) with the correct `CreateClassAsync(new CssClassDef { ... })` usage and add the necessary Models using directive.
- Testing guide: Correct the casing of the `dotnet test` command.

No code changes; only documentation updates. CI workflow already covers build and tests.

Related: #12

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author